### PR TITLE
feat: application lifecycle management

### DIFF
--- a/examples/terminal/main.js
+++ b/examples/terminal/main.js
@@ -35,6 +35,7 @@ if (!process.env.CARLO) {
 
 (async () => {
   const app = await carlo.launch({ bgcolor: '#2b2e3b' });
+  app.on('exit', () => process.exit());
   app.serveFolder(__dirname + '/www');
   app.serveFolder(__dirname + '/node_modules', 'node_modules');
 

--- a/lib/carlo.js
+++ b/lib/carlo.js
@@ -24,19 +24,25 @@ const {Color} = require('./color');
 const fs = require('fs');
 const util = require('util');
 const {URL} = require('url');
+const EventEmitter = require('events');
 const fsReadFile = util.promisify(fs.readFile);
 
-class App {
+class App extends EventEmitter {
   /**
    * @param {!Page} page Puppeteer page
    * @param {!RpcServer} rpcServer
    */
   constructor(page, rpcServer) {
+    super();
     this.www_ = new Map();
     this.page_ = page;
     this.page_.on('request', this.requestIntercepted_.bind(this));
-    this.page_.on('close', () => process.exit());
+    this.page_.on('close', () => this.emit(App.Events.Exit));
     this.rpcServer_ = rpcServer;
+  }
+
+  async exit() {
+    await this.browser_.close();
   }
 
   /**
@@ -116,6 +122,10 @@ class App {
     }
     request.continue();
   }
+}
+
+App.Events = {
+  Exit: 'exit',
 }
 
 const imageContentTypes = new Map([

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carlo",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Carlo is a framework for rendering Node data structures using Chrome browser.",
   "repository": "github:GoogleChromeLabs/carlo",
   "engines": {
@@ -9,8 +9,7 @@
   "directories": {
     "lib": "lib"
   },
-  "scripts": {
-  },
+  "scripts": {},
   "keywords": [],
   "author": "The Chromium Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
This patch:
- introduces `app.on('exit')` event that's fired when browser
  is closed
- adds `app.exit()` method to terminate running browser