### PR TITLE
feat(launch): add chromeArgs option

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,6 +7,7 @@
   - `bgcolor` <[string]> background color using hex notation, defaults to `#ffffff`.
   - `userDataDir` <[string]> Path to a [User Data Directory](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md). This folder is created upon the first app launch and contains user settings and Web storage data. Defaults to `.profile`.
   - `executablePath` <[string]> Path to a Chromium or Chrome executable to run instead of the automatically located Chrome. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). Carlo is only guaranteed to work with the latest Chrome stable version.
+  - 'chromeArgs' <[string|array]> An argument or array of arguments to be passed directly to chrome
 - returns: <[Promise]<App>> Promise which resolves to the app instance.
 
 Launches the browser.

--- a/lib/carlo.js
+++ b/lib/carlo.js
@@ -193,6 +193,12 @@ async function launch(options = {}) {
       `--app=data:text/html,<style>html{background:${bgcolorHex};}</style>`,
       `--enable-features=NetworkService`,
   ];
+  if (options.chromeArgs) {
+    if (typeof options.chromeArgs === 'string')
+      args.push(options.chromeArgs)
+    else
+      args.push(...options.chromeArgs);
+  }
   if (options.width && options.height)
       args.push(`--window-size=${options.width},${options.height}`);
 


### PR DESCRIPTION
closes: #25 

May make sense to not expose this. Thoughts?