### PR TITLE
Add badge to display install size

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <!-- [START badges] -->
 [![NPM carlo package](https://img.shields.io/npm/v/carlo.svg)](https://npmjs.org/package/carlo)
+[![Install Size](https://packagephobia.now.sh/badge?p=carlo)](https://packagephobia.now.sh/result?p=carlo)
 <!-- [END badges] -->
 
 > Carlo provides Node applications with the rich rendering capabilities powered by the [Google Chrome](https://www.google.com/chrome/) browser.


### PR DESCRIPTION
I think one of the defining features is that [carlo](https://packagephobia.now.sh/result?p=carlo) is significantly smaller than [electron](https://packagephobia.now.sh/result?p=electron) (for obvious reasons).

This adds a badge to show the npm install size.