### PR TITLE
Give download URL of Chrome if executable is not found

### DIFF
--- a/lib/carlo.js
+++ b/lib/carlo.js
@@ -184,7 +184,7 @@ async function launch(options = {}) {
 
   const executablePath = options.executablePath || findChrome().pop();
   if (!executablePath) {
-    console.error('Could not find Chrome installation, please make sure Chrome browser is installed.');
+    console.error('Could not find Chrome installation, please make sure Chrome browser is installed from https://www.google.com/chrome/.');
     process.exit(0);
     return;
   }


### PR DESCRIPTION
Provide a more actionable error message if Chrome executable is not found.