### PR TITLE
feat(readme): amplify usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ const carlo = require('carlo');
   // Launch the browser.
   const app = await carlo.launch();
 
+  // Terminate Node.js process on app window closing.
+  app.on('exit', () => process.exit());
+
   // Tell carlo where your web files are located.
   app.serveFolder(__dirname);
 


### PR DESCRIPTION
Without this line, Node.js process and some invisible Chrome instances hang after main app window closed, which may be confusing for a newcomer.