### PR TITLE
linters against staged git

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,12 @@
   "directories": {
     "lib": "lib"
   },
+  "lint-staged": {
+    "*.js": [ "eslint --fix", "git add" ]
+  },
   "scripts": {
-    "lint": "([ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .)"
+    "lint": "([ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .)",
+    "precommit": "lint-staged"
   },
   "keywords": [],
   "author": "The Chromium Authors",
@@ -19,6 +23,8 @@
     "puppeteer-core": "^1.9.0"
   },
   "devDependencies": {
-    "eslint": "^5.8.0"
+    "eslint": "^5.8.0",
+    "husky": "^1.1.3",
+    "lint-staged": "^8.0.4"
   }
 }


### PR DESCRIPTION
# Main changes 🔨 

The following packages were added:

- husky
- lint-staged

## Why were these packages added? 

These packages allow us to execute a **linters against staged git files** , you can make sure that there are no errors in the repository and apply the code style.