### PR TITLE
docs: update examples to use `npm start`

### DIFF
--- a/examples/systeminfo/README.md
+++ b/examples/systeminfo/README.md
@@ -9,7 +9,7 @@ npm i
 Run application
 
 ```bash
-node main.js
+npm start
 ```
 
 Optionally package as executable

--- a/examples/systeminfo/package.json
+++ b/examples/systeminfo/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "pack": "pkg package.json",
-    "run": "node main.js"
+    "start": "node main.js"
   },
   "bin": {
     "systeminfo-app": "./main.js"

--- a/examples/terminal/README.md
+++ b/examples/terminal/README.md
@@ -9,5 +9,5 @@ npm i
 Run application
 
 ```bash
-node main.js
+npm start
 ```

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "pack": "pkg package.json",
-    "run": "node main.js"
+    "start": "node main.js"
   },
   "bin": {
     "xterm-app": "./main.js"


### PR DESCRIPTION
This PR updates the two examples to use the well-known `npm start` script convention, instead of the existing `run` script name, which would be invoked by the counterintuitive command, `npm run run`.