### PR TITLE
Update load() uri with default parameter

### DIFF
--- a/lib/carlo.js
+++ b/lib/carlo.js
@@ -105,7 +105,7 @@ class App extends EventEmitter {
       throw new Error('Please call app.serveFolder(__dirname) or point to ' +
                       'other folder(s) with your web files');
     }
-    this.page_.goto(`https://domain/${uri}`, {timeout: 0});
+    this.page_.goto(`https://domain/${uri||''}`, {timeout: 0});
     return this.initializeRpc_(params);
   }
 


### PR DESCRIPTION
#56 related
If `index.html` does not exist it'll hit `HTTP 404`
```javascript
app.serveOrigin('https://google.com');
app.serveFolder(__dirname);
await app.load('index.html'); // <-- 404
```
```javascript
await app.load(); // would lead to domain/undefined
await app.load(''); // would look a bit hacky
```
Updated the `load()` `uri` with default value