### PR TITLE
fix(color): use template string instead of sprintf

### DIFF
--- a/lib/carlo.js
+++ b/lib/carlo.js
@@ -84,7 +84,7 @@ class App extends EventEmitter {
     let folders = this.www_.get(prefix);
     if (!folders) {
       folders = [];
-      this.www_.set(prefix, folders)
+      this.www_.set(prefix, folders);
     }
     folders.push(folder);
   }
@@ -110,7 +110,7 @@ class App extends EventEmitter {
       throw new Error('Please call app.serveFolder(__dirname) or point to ' +
                       'other folder(s) with your web files');
     }
-    this.page_.goto(`https://domain/${uri||''}`, {timeout: 0});
+    this.page_.goto(`https://domain/${uri || ''}`, {timeout: 0});
     return this.initializeRpc_(params);
   }
 

--- a/lib/color.js
+++ b/lib/color.js
@@ -47,7 +47,6 @@ class Color {
    * @return {?Color}
    */
   static parse(text) {
-    // Simple - #hex, nickname
     const value = text.toLowerCase().replace(/\s+/g, '');
     const simple = /^(?:#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8}))$/i;
     let match = value.match(simple);
@@ -358,54 +357,34 @@ class Color {
       case Color.Format.RGB:
         if (this.hasAlpha())
           return null;
-        return String.sprintf(
-            'rgb(%d, %d, %d)', toRgbValue(this._rgba[0]), toRgbValue(this._rgba[1]), toRgbValue(this._rgba[2]));
+        return `rgb(${toRgbValue(this._rgba[0])}, ${toRgbValue(this._rgba[1])}, ${toRgbValue(this._rgba[2])})`;
       case Color.Format.RGBA:
-        return String.sprintf(
-            'rgba(%d, %d, %d, %f)', toRgbValue(this._rgba[0]), toRgbValue(this._rgba[1]), toRgbValue(this._rgba[2]),
-            this._rgba[3]);
+        return `rgba(${toRgbValue(this._rgba[0])}, ${toRgbValue(this._rgba[1])}, ${toRgbValue(this._rgba[2])}, ${this._rgba[3]})`;
       case Color.Format.HSL:
         if (this.hasAlpha())
           return null;
         const hsl = this.hsla();
-        return String.sprintf(
-            'hsl(%d, %d%, %d%)', Math.round(hsl[0] * 360), Math.round(hsl[1] * 100), Math.round(hsl[2] * 100));
+        return `hsl(${Math.round(hsl[0] * 360)}, ${Math.round(hsl[1] * 100)}%, ${Math.round(hsl[2] * 100)}%)`;
       case Color.Format.HSLA:
         const hsla = this.hsla();
-        return String.sprintf(
-            'hsla(%d, %d%, %d%, %f)', Math.round(hsla[0] * 360), Math.round(hsla[1] * 100), Math.round(hsla[2] * 100),
-            hsla[3]);
+        return `hsla(${Math.round(hsla[0] * 360)}, ${Math.round(hsla[1] * 100)}%, ${Math.round(hsla[2] * 100)}%, ${hsla[3]})`;
       case Color.Format.HEXA:
-        return String
-            .sprintf(
-                '#%s%s%s%s', toHexValue(this._rgba[0]), toHexValue(this._rgba[1]), toHexValue(this._rgba[2]),
-                toHexValue(this._rgba[3]))
-            .toLowerCase();
+        return `#${toHexValue(this._rgba[0])}${toHexValue(this._rgba[1])}${toHexValue(this._rgba[2])}${toHexValue(this._rgba[3])}`.toLowerCase();
       case Color.Format.HEX:
         if (this.hasAlpha())
           return null;
-        return String
-            .sprintf('#%s%s%s', toHexValue(this._rgba[0]), toHexValue(this._rgba[1]), toHexValue(this._rgba[2]))
-            .toLowerCase();
+        return `#${toHexValue(this._rgba[0])}${toHexValue(this._rgba[1])}${toHexValue(this._rgba[2])}`.toLowerCase();
       case Color.Format.ShortHEXA:
         const hexFormat = this.detectHEXFormat();
         if (hexFormat !== Color.Format.ShortHEXA && hexFormat !== Color.Format.ShortHEX)
           return null;
-        return String
-            .sprintf(
-                '#%s%s%s%s', toShortHexValue(this._rgba[0]), toShortHexValue(this._rgba[1]),
-                toShortHexValue(this._rgba[2]), toShortHexValue(this._rgba[3]))
-            .toLowerCase();
+        return `#${toShortHexValue(this._rgba[0])}${toShortHexValue(this._rgba[1])}${toShortHexValue(this._rgba[2])}${toShortHexValue(this._rgba[3])}`.toLowerCase();
       case Color.Format.ShortHEX:
         if (this.hasAlpha())
           return null;
         if (this.detectHEXFormat() !== Color.Format.ShortHEX)
           return null;
-        return String
-            .sprintf(
-                '#%s%s%s', toShortHexValue(this._rgba[0]), toShortHexValue(this._rgba[1]),
-                toShortHexValue(this._rgba[2]))
-            .toLowerCase();
+        return `#${toShortHexValue(this._rgba[0])}${toShortHexValue(this._rgba[1])}${toShortHexValue(this._rgba[2])}`.toLowerCase();
     }
 
     return this._originalText;

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {TestRunner, Reporter, Matchers} = require('@pptr/testrunner');
+const { Color } = require('./color.js');
+
+// Runner holds and runs all the tests
+const runner = new TestRunner({
+  parallel: 2, // run 2 parallel threads
+  timeout: 1000, // setup timeout of 1 second per test
+});
+// Simple expect-like matchers
+const {expect} = new Matchers();
+
+// Extract jasmine-like DSL into the global namespace
+const {describe, xdescribe, fdescribe} = runner;
+const {it, fit, xit} = runner;
+const {beforeAll, beforeEach, afterAll, afterEach} = runner;
+
+describe('color', () => {
+  it('asString', async(state, test) => {
+    color = Color.parse('rgb(94, 126, 91)');
+    expect(color.asString(Color.Format.RGB)).toBe('rgb(94, 126, 91)');
+    expect(color.asString(Color.Format.RGBA)).toBe('rgba(94, 126, 91, 1)');
+    expect(color.asString(Color.Format.HSL)).toBe('hsl(115, 16%, 43%)');
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(115, 16%, 43%, 1)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#5e7e5bff');
+    expect(color.asString(Color.Format.HEX)).toBe('#5e7e5b');
+    expect(color.asString(Color.Format.ShortHEXA)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEX)).toBe(null);
+    expect(color.asString()).toBe('rgb(94, 126, 91)');
+
+    color = Color.parse('rgba(94 126 91)');
+    expect(color.asString(Color.Format.RGB)).toBe('rgba(94 126 91)');
+    expect(color.asString(Color.Format.RGBA)).toBe('rgba(94, 126, 91, 1)');
+    expect(color.asString(Color.Format.HSL)).toBe('hsl(115, 16%, 43%)');
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(115, 16%, 43%, 1)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#5e7e5bff');
+    expect(color.asString(Color.Format.HEX)).toBe('#5e7e5b');
+    expect(color.asString(Color.Format.ShortHEXA)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEX)).toBe(null);
+    expect(color.asString()).toBe('rgb(94, 126, 91)');
+
+    color = Color.parse('rgba(94, 126, 91, 0.5)');
+    expect(color.asString(Color.Format.RGB)).toBe(null);
+    expect(color.asString(Color.Format.RGBA)).toBe('rgba(94, 126, 91, 0.5)');
+    expect(color.asString(Color.Format.HSL)).toBe(null);
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(115, 16%, 43%, 0.5)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#5e7e5b80');
+    expect(color.asString(Color.Format.HEX)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEXA)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEX)).toBe(null);
+    expect(color.asString()).toBe('rgba(94, 126, 91, 0.5)');
+
+    color = Color.parse('rgb(94 126 91 / 50%)');
+    expect(color.asString(Color.Format.RGB)).toBe(null);
+    expect(color.asString(Color.Format.RGBA)).toBe('rgb(94 126 91 / 50%)');
+    expect(color.asString(Color.Format.HSL)).toBe(null);
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(115, 16%, 43%, 0.5)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#5e7e5b80');
+    expect(color.asString(Color.Format.HEX)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEXA)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEX)).toBe(null);
+    expect(color.asString()).toBe('rgba(94, 126, 91, 0.5)');
+
+    color = Color.parse('hsl(212, 55%, 32%)');
+    expect(color.asString(Color.Format.RGB)).toBe('rgb(37, 79, 126)');
+    expect(color.asString(Color.Format.RGBA)).toBe('rgba(37, 79, 126, 1)');
+    expect(color.asString(Color.Format.HSL)).toBe('hsl(212, 55%, 32%)');
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(212, 55%, 32%, 1)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#254f7eff');
+    expect(color.asString(Color.Format.HEX)).toBe('#254f7e');
+    expect(color.asString(Color.Format.ShortHEXA)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEX)).toBe(null);
+    expect(color.asString()).toBe('hsl(212, 55%, 32%)');
+
+    color = Color.parse('hsla(212 55% 32%)');
+    expect(color.asString(Color.Format.RGB)).toBe('rgb(37, 79, 126)');
+    expect(color.asString(Color.Format.RGBA)).toBe('rgba(37, 79, 126, 1)');
+    expect(color.asString(Color.Format.HSL)).toBe('hsla(212 55% 32%)');
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(212, 55%, 32%, 1)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#254f7eff');
+    expect(color.asString(Color.Format.HEX)).toBe('#254f7e');
+    expect(color.asString(Color.Format.ShortHEXA)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEX)).toBe(null);
+    expect(color.asString()).toBe('hsl(212, 55%, 32%)');
+
+    color = Color.parse('hsla(212, 55%, 32%, 0.5)');
+    expect(color.asString(Color.Format.RGB)).toBe(null);
+    expect(color.asString(Color.Format.RGBA)).toBe('rgba(37, 79, 126, 0.5)');
+    expect(color.asString(Color.Format.HSL)).toBe(null);
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(212, 55%, 32%, 0.5)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#254f7e80');
+    expect(color.asString(Color.Format.HEX)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEXA)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEX)).toBe(null);
+    expect(color.asString()).toBe('hsla(212, 55%, 32%, 0.5)');
+
+    color = Color.parse('hsla(212  55%  32% /  50%)');
+    expect(color.asString(Color.Format.RGB)).toBe(null);
+    expect(color.asString(Color.Format.RGBA)).toBe('rgba(37, 79, 126, 0.5)');
+    expect(color.asString(Color.Format.HSL)).toBe(null);
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(212  55%  32% /  50%)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#254f7e80');
+    expect(color.asString(Color.Format.HEX)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEXA)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEX)).toBe(null);
+    expect(color.asString()).toBe('hsla(212, 55%, 32%, 0.5)');
+
+    color = Color.parse('hsla(212deg 55% 32% / 50%)');
+    expect(color.asString(Color.Format.RGB)).toBe(null);
+    expect(color.asString(Color.Format.RGBA)).toBe('rgba(37, 79, 126, 0.5)');
+    expect(color.asString(Color.Format.HSL)).toBe(null);
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(212deg 55% 32% / 50%)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#254f7e80');
+    expect(color.asString(Color.Format.HEX)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEXA)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEX)).toBe(null);
+    expect(color.asString()).toBe('hsla(212, 55%, 32%, 0.5)');
+
+    color = Color.parse('#12345678');
+    expect(color.asString(Color.Format.RGB)).toBe(null);
+    expect(color.asString(Color.Format.RGBA)).toBe('rgba(18, 52, 86, 0.47058823529411764)');
+    expect(color.asString(Color.Format.HSL)).toBe(null);
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(210, 65%, 20%, 0.47058823529411764)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#12345678');
+    expect(color.asString(Color.Format.HEX)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEXA)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEX)).toBe(null);
+    expect(color.asString()).toBe('#12345678');
+
+    color = Color.parse('#00FFFF');
+    expect(color.asString(Color.Format.RGB)).toBe('rgb(0, 255, 255)');
+    expect(color.asString(Color.Format.RGBA)).toBe('rgba(0, 255, 255, 1)');
+    expect(color.asString(Color.Format.HSL)).toBe('hsl(180, 100%, 50%)');
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(180, 100%, 50%, 1)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#00ffffff');
+    expect(color.asString(Color.Format.HEX)).toBe('#00FFFF');
+    expect(color.asString(Color.Format.ShortHEXA)).toBe('#0fff');
+    expect(color.asString(Color.Format.ShortHEX)).toBe('#0ff');
+    expect(color.asString()).toBe('#00ffff');
+
+    color = Color.parse('#1234');
+    expect(color.asString(Color.Format.RGB)).toBe(null);
+    expect(color.asString(Color.Format.RGBA)).toBe('rgba(17, 34, 51, 0.26666666666666666)');
+    expect(color.asString(Color.Format.HSL)).toBe(null);
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(210, 50%, 13%, 0.26666666666666666)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#11223344');
+    expect(color.asString(Color.Format.HEX)).toBe(null);
+    expect(color.asString(Color.Format.ShortHEXA)).toBe('#1234');
+    expect(color.asString(Color.Format.ShortHEX)).toBe(null);
+    expect(color.asString()).toBe('#1234');
+
+    color = Color.parse('#0FF');
+    expect(color.asString(Color.Format.RGB)).toBe('rgb(0, 255, 255)');
+    expect(color.asString(Color.Format.RGBA)).toBe('rgba(0, 255, 255, 1)');
+    expect(color.asString(Color.Format.HSL)).toBe('hsl(180, 100%, 50%)');
+    expect(color.asString(Color.Format.HSLA)).toBe('hsla(180, 100%, 50%, 1)');
+    expect(color.asString(Color.Format.HEXA)).toBe('#00ffffff');
+    expect(color.asString(Color.Format.HEX)).toBe('#00ffff');
+    expect(color.asString(Color.Format.ShortHEXA)).toBe('#0fff');
+    expect(color.asString(Color.Format.ShortHEX)).toBe('#0FF');
+    expect(color.asString()).toBe('#0ff');
+  });
+});
+
+// Reporter subscribes to TestRunner events and displays information in terminal
+new Reporter(runner);
+
+// Run all tests.
+runner.run();

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "lint": "([ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .)",
-    "test": "node rpc/test.js"
+    "test": "node rpc/test.js lib/test.js"
   },
   "keywords": [],
   "author": "The Chromium Authors",

--- a/rpc/test.js
+++ b/rpc/test.js
@@ -169,7 +169,7 @@ describe('rpc', () => {
       expect(true).toBeFalsy();
     } catch (e) {
       expect(e.toString()).toContain('is not a function');
-    }    
+    }
   });
   it('materialize handle', async(state, test) => {
     const object = {};


### PR DESCRIPTION
carlo does not have own String.sprintf implementation, we can use
template string instead.
drive-by: fixed linter errors.

Fixes https://github.com/GoogleChromeLabs/carlo/issues/64