### PR TITLE
fix(rpc): throw meaningful error when object ref chain is too long

### DIFF
--- a/rpc/rpc.js
+++ b/rpc/rpc.js
@@ -232,9 +232,14 @@ class Rpc {
   /**
    * Wraps call argument as a protocol structures.
    * @param {*} param
+   * @param {number=} maxDepth
    * @return {*}
    */
-  wrap_(param) {
+  wrap_(param, maxDepth) {
+    maxDepth = typeof maxDepth === 'undefined' ? 1000 : maxDepth;
+    if (!maxDepth)
+      throw new Error('Object reference chain is too long');
+    maxDepth--;
     if (!param)
       return param;
 
@@ -244,12 +249,12 @@ class Rpc {
     }
 
     if (param instanceof Array)
-      return param.map(item => this.wrap_(item));
+      return param.map(item => this.wrap_(item, maxDepth));
 
     if (typeof param === 'object') {
       const result = {};
       for (const key in param)
-        result[key] = this.wrap_(param[key]);
+        result[key] = this.wrap_(param[key], maxDepth);
       return result;
     }
 

--- a/rpc/test.js
+++ b/rpc/test.js
@@ -91,6 +91,20 @@ describe('rpc', () => {
     const result = await foo.call({a: [foo]});
     expect(result).toBe('name');
   });
+  it('call method with object with recursive link', async(state, test) => {
+    class Foo {
+      async call(val) { return await val.a[0].name(); }
+      name() { return 'name'; }
+    }
+    const foo = rpc.handle(new Foo());
+    const a = {};
+    a.a = a;
+    try {
+      await foo.call({a});
+    } catch (e) {
+      expect(e.message).toBe('Object reference chain is too long');
+    }
+  });
   it('call method that does not exist', async(state, test) => {
     class Foo {
     }


### PR DESCRIPTION
Fixes  https://github.com/GoogleChromeLabs/carlo/issues/65