### PR TITLE
fix(api.md): fix some nits in API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,33 +11,33 @@
   * [App.evaluate(pageFunction[, ...args])](#appevaluatepagefunction-args)
   * [App.exit()](#appexit)
   * [App.exposeFunction(name, carloFunction)](#appexposefunctionname-carlofunction)
-  * [App.load(uri[, params])](#apploaduri-params)
+  * [App.load(uri[, ...params])](#apploaduri-params)
   * [App.mainWindow()](#appmainwindow)
   * [App.serveFolder(folder[, prefix])](#appservefolderfolder-prefix)
   * [App.serveOrigin(origin)](#appserveoriginorigin)
   * [App.windows()](#appwindows)
 - [class: Window](#class-window)
-  * [Window.bringToFront()](#windowbringtofront)
   * [Window.bounds()](#windowbounds)
+  * [Window.bringToFront()](#windowbringtofront)
   * [Window.close()](#windowclose)
   * [Window.evaluate(pageFunction[, ...args])](#windowevaluatepagefunction-args)
   * [Window.exposeFunction(name, carloFunction)](#windowexposefunctionname-carlofunction)
   * [Window.fullscreen()](#windowfullscreen)
-  * [Window.load(uri[, params])](#windowloaduri-params)
+  * [Window.load(uri[, ...params])](#windowloaduri-params)
   * [Window.maximize()](#windowmaximize)
   * [Window.minimize()](#windowminimize)
   * [Window.serveFolder(folder[, prefix])](#windowservefolderfolder-prefix)
   * [Window.serveOrigin(origin)](#windowserveoriginorigin)
-  * [Window.setBounds()](#windowsetbounds)
+  * [Window.setBounds()](#windowsetboundsbounds)
 
 #### carlo.launch([options])
-- `options` <[Object]>  Set of configurable options to set on the app. Can have the following fields:
-  - `width` <[number]> app window width in pixels.
-  - `height` <[number]> app window height in pixels.
-  - `top`: <[number]> app window top offset in pixels.
-  - `left` <[number]> app window left offset in pixels.
-  - `bgcolor` <[string]> background color using hex notation, defaults to `#ffffff`.
-  - `userDataDir` <[string]> Path to a [User Data Directory](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md). This folder is created upon the first app launch and contains user settings and Web storage data. Defaults to `.profile`.
+- `options` <[Object]> Set of configurable options to set on the app. Can have the following fields:
+  - `width` <[number]> App window width in pixels.
+  - `height` <[number]> App window height in pixels.
+  - `top`: <[number]> App window top offset in pixels.
+  - `left` <[number]> App window left offset in pixels.
+  - `bgcolor` <[string]> Background color using hex notation, defaults to `'#ffffff'`.
+  - `userDataDir` <[string]> Path to a [User Data Directory](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md). This folder is created upon the first app launch and contains user settings and Web storage data. Defaults to `'.profile'`.
   - `executablePath` <[string]> Path to a Chromium or Chrome executable to run instead of the automatically located Chrome. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). Carlo is only guaranteed to work with the latest Chrome stable version.
   - `args` <[Array]<[string]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](https://peter.sh/experiments/chromium-command-line-switches/).
 - `return`: <[Promise]<[App]>> Promise which resolves to the app instance.
@@ -50,13 +50,15 @@ Launches the browser.
 Emitted when the App window closes.
 
 #### App.createWindow([options])
-- `options` <[Object]>  Set of configurable options to set on the app. Can have the following fields:
-  - `width` <[number]> window width in pixels, defaults to app width.
-  - `height` <[number]> window height in pixels, defaults to app height.
-  - `top` <[number]> window top in pixels, defaults to app width.
-  - `left` <[number]> window left in pixels, defaults to app height.
-  - `bgcolor` <[string]> background color using hex notation, defaults to app bgcolor.
+- `options` <[Object]> Set of configurable options to set on the app. Can have the following fields:
+  - `width` <[number]> Window width in pixels, defaults to app width.
+  - `height` <[number]> Window height in pixels, defaults to app height.
+  - `top` <[number]> Window top in pixels, defaults to app top.
+  - `left` <[number]> Window left in pixels, defaults to app left.
+  - `bgcolor` <[string]> Background color using hex notation, defaults to app `bgcolor`.
 - `return`: <[Promise]<[Window]>> Promise which resolves to the window instance.
+
+Creates a new app window.
 
 #### App.evaluate(pageFunction[, ...args])
 
@@ -71,9 +73,9 @@ Closes the browser window.
 
 Shortcut to the main window's [Window.exposeFunction(name, carloFunction)](#windowexposefunctionname-carlofunction)
 
-#### App.load(uri[, params])
+#### App.load(uri[, ...params])
 
-Shortcut to the main window's [Window.load(uri[, params])](#windowloaduri-params).
+Shortcut to the main window's [Window.load(uri[, ...params])](#windowloaduri-params).
 
 #### App.mainWindow()
 - `return`: <[Window]> Returns main window.
@@ -90,50 +92,48 @@ Shortcut to the main window's [Window.serveFolder(folder[, prefix])](#windowserv
 Shortcut to the main window's [Window.serveOrigin(origin)](#windowserveoriginorigin)
 
 #### App.windows()
-- `return`: <[Array][Window]>> Returns all currently opened windows.
+- `return`: <[Array]<[Window]>> Returns all currently opened windows.
 
 Running app guarantees to have at least one open window.
 
 ### class: Window
 
-#### event: 'exit'
-Emitted when the App window closes.
-
-#### Window.bringToFront()
-
-Brings this window to front.
-
 #### Window.bounds()
-- `return`
-  - `top` <[number]> top offset in pixels
-  - `left` <[number]> left offset in pixels
-  - `width` <[number]> width in pixels
-  - `height` <[number]> height in pixels
+- `return`: <[Promise]<[Object]>>
+  - `top` <[number]> Top offset in pixels.
+  - `left` <[number]> Left offset in pixels.
+  - `width` <[number]> Width in pixels.
+  - `height` <[number]> Height in pixels.
 
 Returns window bounds.
 
+#### Window.bringToFront()
+- `return`: <[Promise]>
+
+Brings this window to front.
+
 #### Window.close()
+- `return`: <[Promise]>
 
 Closes this window.
 
 #### Window.evaluate(pageFunction[, ...args])
-- `pageFunction` <[function]|[string]> Function to be evaluated in the page context
-- `...args` <...[Serializable]> Arguments to pass to `pageFunction`
-- `return`: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`
+- `pageFunction` <[function]|[string]> Function to be evaluated in the page context.
+- `...args` <...[Serializable]> Arguments to pass to `pageFunction`.
+- `return`: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`.
 
-If the function passed to the `page.evaluate` returns a [Promise], then `page.evaluate` would wait for the promise to resolve and return its value.
+If the function passed to the `Window.evaluate` returns a [Promise], then `Window.evaluate` would wait for the promise to resolve and return its value.
 
-If the function passed to the `App.evaluate` returns a non-[Serializable] value, then `page.evaluate` resolves to `undefined`.
+If the function passed to the `Window.evaluate` returns a non-[Serializable] value, then `Window.evaluate` resolves to `undefined`.
 
-Passing arguments to `pageFunction`:
 ```js
-const result = await app.evaluate(() => navigator.userAgent);
+const result = await window.evaluate(() => navigator.userAgent);
 console.log(result);  // prints "<UA>" in Node console
 ```
 
 Passing arguments to `pageFunction`:
 ```js
-const result = await app.evaluate(x => {
+const result = await window.evaluate(x => {
   return Promise.resolve(8 * x);
 }, 7);
 console.log(result);  // prints "56" in Node console
@@ -141,22 +141,22 @@ console.log(result);  // prints "56" in Node console
 
 A string can also be passed in instead of a function:
 ```js
-console.log(await app.evaluate('1 + 2'));  // prints "3"
+console.log(await window.evaluate('1 + 2'));  // prints "3"
 const x = 10;
-console.log(await app.evaluate(`1 + ${x}`));  // prints "11"
+console.log(await window.evaluate(`1 + ${x}`));  // prints "11"
 ```
 
 #### Window.exposeFunction(name, carloFunction)
-- `name` <[string]> Name of the function on the window object
+- `name` <[string]> Name of the function on the window object.
 - `carloFunction` <[function]> Callback function which will be called in Carlo's context.
 - `return`: <[Promise]>
 
 The method adds a function called `name` on the page's `window` object.
-When called, the function executes `carloFunction` in node.js and returns a [Promise] which resolves to the return value of `carloFunction`.
+When called, the function executes `carloFunction` in Node.js and returns a [Promise] which resolves to the return value of `carloFunction`.
 
 If the `carloFunction` returns a [Promise], it will be awaited.
 
-> **NOTE** Functions installed via `App.exposeFunction` survive navigations.
+> **NOTE** Functions installed via `Window.exposeFunction` survive navigations.
 
 An example of adding an `md5` function into the page:
 
@@ -183,10 +183,11 @@ md5('digest').then(result => document.body.textContent = result);
 ```
 
 #### Window.fullscreen()
+- `return`: <[Promise]>
 
 Turns the window into the full screen mode. Behavior is platform-specific.
 
-#### Window.load(uri[, params])
+#### Window.load(uri[, ...params])
 - `uri` <[string]> Path to the resource relative to the folder passed into [`serveFolder()`].
 - `params` <*> Optional parameters to pass to the web application. Parameters can be
 primitive types, <[Array]>, <[Object]> or [rpc](https://github.com/GoogleChromeLabs/carlo/blob/master/rpc/rpc.md) `handles`.
@@ -209,7 +210,7 @@ carlo.launch().then(async app => {
 
 class Backend {
   hello(name) {
-    console.log('Hello ' + name);
+    console.log(`Hello ${name}`);
     return 'Backend is happy';
   }
 }
@@ -220,7 +221,7 @@ class Backend {
 <script>
 class Frontend {
   hello(name) {
-    console.log('Hello ' + name);
+    console.log(`Hello ${name}`);
     return 'Frontend is happy';
   }
 }
@@ -234,10 +235,12 @@ async function load(backend) {
 ```
 
 #### Window.maximize()
+- `return`: <[Promise]>
 
 Maximizes the window. Behavior is platform-specific.
 
 #### Window.minimize()
+- `return`: <[Promise]>
 
 Minimizes the window. Behavior is platform-specific.
 
@@ -255,8 +258,8 @@ const carlo = require('carlo');
 
 carlo.launch().then(async app => {
   app.on('exit', () => process.exit());
-  app.serveFolder(__dirname + '/www');
-  app.serveFolder(__dirname + '/node_modules', 'node_modules');
+  app.serveFolder(`${__dirname}/www`);
+  app.serveFolder(`${__dirname}/node_modules`, 'node_modules');
   await app.load('index.html');
 });
 ```
@@ -279,7 +282,6 @@ This mode can be used for the fast development mode available in web frameworks.
 
 An example of adding the local `http://localhost:8080` origin:
 
-`main.js`
 ```js
 const carlo = require('carlo');
 
@@ -290,34 +292,26 @@ carlo.launch().then(async app => {
   await app.load('index.html');
 });
 ```
-***www***/`index.html`
-```html
-<style>body { white-space: pre; }</style>
-<script>
-fetch('node_modules/carlo/package.json')
-    .then(response => response.text())
-    .then(text => document.body.textContent = text);
-</script>
-```
 
 #### Window.setBounds(bounds)
-- `bounds` Window bounds
-  - `top`: <[number]> top offset in pixels
-  - `left` <[number]> left offset in pixels
-  - `width` <[number]> width in pixels
-  - `height` <[number]> height in pixels
+- `bounds` <[Object]> Window bounds:
+  - `top`: <[number]> Top offset in pixels.
+  - `left` <[number]> Left offset in pixels.
+  - `width` <[number]> Width in pixels.
+  - `height` <[number]> Height in pixels.
+- `return`: <[Promise]>
 
-Sets window bounds. Parameters `top`, `left`, `width` and `hight` are all optional. Dimension or
+Sets window bounds. Parameters `top`, `left`, `width` and `height` are all optional. Dimension or
 the offset is only applied when specified.
 
-[`serveFolder()`]: #appservefolderfolder-prefix
+[`serveFolder()`]: #windowservefolderfolder-prefix
 [App]: #class-app
-[Window]: #class-window
 [Array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array "Array"
 [Buffer]: https://nodejs.org/api/buffer.html#buffer_class_buffer "Buffer"
 [Object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object "Object"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [Serializable]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description "Serializable"
+[Window]: #class-window
 [boolean]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type "Boolean"
 [function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function "Function"
 [number]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type "Number"


### PR DESCRIPTION
* Fix typos.
* Fix link anchors.
* Fix sorting of sections and references.
* Fix copy-paste artifacts.
* Fix formatting/markdown issues.
* Unify casing and punctuation.
* Unify using template literals instead of string concatenation.
* Add missing types.
* Add missing return values.
* Add method descriptions.
* Add backticks for API entities.
* Add quotes to emphasize string value types.