### PR TITLE
fix(rpc): it should be possible to wrap handle

### DIFF
--- a/rpc/rpc.js
+++ b/rpc/rpc.js
@@ -45,7 +45,10 @@ class Handle {
 
     const target = {};
     target[handleSymbol] = this;
-    this.proxy_ = new Proxy(target, { get: Handle.proxyHandler_ });
+    this.proxy_ = new Proxy(target, {
+      get: Handle.proxyHandler_,
+      has: () => true
+    });
   }
 
   /**

--- a/rpc/test.js
+++ b/rpc/test.js
@@ -210,6 +210,11 @@ describe('rpc', () => {
     await foo.foo(foo);
     expect(foo === foo2).toBeTruthy();
   });
+  it('handle wrapped in handle', async(state, test) => {
+    class Foo { a() { return 42; } };
+    const foo = rpc.handle(new Foo());
+    expect(await rpc.handle(foo).a()).toBe(42);
+  });
   it('parent / child communication', async(state, test) => {
     const messages = [];
     class Root {


### PR DESCRIPTION
It can be useful in following example where backend is exposed to
another process.
```javascript
class Backend {
  async createService(fullName, ...args) {
    return rpc.handle(await rpc_process.spawn(fullName, args));
  }
};
```