### PR TITLE
feat(carlo): added experimental configurations options for launch

### DIFF
--- a/lib/carlo.js
+++ b/lib/carlo.js
@@ -471,7 +471,7 @@ async function launch(options = {}) {
   if (!options.bgcolor)
     options.bgcolor = '#ffffff';
 
-  const executablePath = options.executablePath || findChrome().pop();
+  const executablePath = options.executablePath || (await findChrome(options.configurations || ['stable'])).pop();
   if (!executablePath) {
     console.error('Could not find Chrome installation, please make sure Chrome browser is installed from https://www.google.com/chrome/.');
     process.exit(0);

--- a/lib/find_chrome.js
+++ b/lib/find_chrome.js
@@ -16,6 +16,8 @@
 
 'use strict';
 
+const puppeteer = require('puppeteer-core');
+
 const fs = require('fs');
 const path = require('path');
 const execSync = require('child_process').execSync;
@@ -215,14 +217,94 @@ function findChromeExecutables(folder) {
   return installations;
 }
 
-function installations() {
+/**
+ * @param {!Array<string>} configurations
+ * @return {!Promise<!Array<string>>}
+ */
+async function installations(configurations) {
+  if (configurations[0] === 'chromium')
+    return [await downloadChromium()];
+  if (configurations[0].startsWith('r'))
+    return [await downloadChromium(configurations[0].substr(1))];
+  let paths = [];
   if (process.platform === 'linux')
-    return linux();
-  if (process.platform === 'win32')
-    return win32();
-  if (process.platform === 'darwin')
-    return darwin();
-  return [];
+    paths = linux();
+  else if (process.platform === 'win32')
+    paths = win32();
+  else if (process.platform === 'darwin')
+    paths = darwin();
+  if (paths.length === 0 && configurations[0] === '*')
+    return [await downloadChromium()];
+  return paths;
+}
+
+/**
+ * @param {string=} targetRevision
+ * @return {!Promise<?string>}
+ */
+async function downloadChromium(targetRevision) {
+  const downloadHost = process.env.CARLO_DOWNLOAD_HOST || process.env.npm_config_carlo_download_host;
+
+  const browserFetcher = puppeteer.createBrowserFetcher({ host: downloadHost });
+
+  const defaultCarloRevision = '599821';
+  const revision = targetRevision || process.env.CARLO_CHROMIUM_REVISION || process.env.npm_config_carlo_chromium_revision
+    || defaultCarloRevision;
+
+  const revisionInfo = browserFetcher.revisionInfo(revision);
+
+  // Do nothing if the revision is already downloaded.
+  if (revisionInfo.local)
+    return revisionInfo.executablePath;
+
+  // Override current environment proxy settings with npm configuration, if any.
+  const NPM_HTTPS_PROXY = process.env.npm_config_https_proxy || process.env.npm_config_proxy;
+  const NPM_HTTP_PROXY = process.env.npm_config_http_proxy || process.env.npm_config_proxy;
+  const NPM_NO_PROXY = process.env.npm_config_no_proxy;
+
+  if (NPM_HTTPS_PROXY)
+    process.env.HTTPS_PROXY = NPM_HTTPS_PROXY;
+  if (NPM_HTTP_PROXY)
+    process.env.HTTP_PROXY = NPM_HTTP_PROXY;
+  if (NPM_NO_PROXY)
+    process.env.NO_PROXY = NPM_NO_PROXY;
+
+  let progressBar = null;
+  let lastDownloadedBytes = 0;
+  try {
+    await browserFetcher.download(revisionInfo.revision, onProgress);
+    let localRevisions = await browserFetcher.localRevisions();
+    console.log('Chromium downloaded to ' + revisionInfo.folderPath);
+    localRevisions = localRevisions.filter(revision => revision !== revisionInfo.revision);
+    // Remove previous chromium revisions.
+    const cleanupOldVersions = localRevisions.map(revision => browserFetcher.remove(revision));
+    await Promise.all(cleanupOldVersions);
+    return browserFetcher.revisionInfo(revision).executablePath;
+  } catch (error) {
+    console.error(`ERROR: Failed to download Chromium r${revision}! Set "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" env variable to skip download.`);
+    console.error(error);
+    return null;
+  }
+
+  function onProgress(downloadedBytes, totalBytes) {
+    if (!progressBar) {
+      const ProgressBar = require('progress');
+      progressBar = new ProgressBar(`Downloading Chromium r${revision} - ${toMegabytes(totalBytes)} [:bar] :percent :etas `, {
+        complete: '=',
+        incomplete: ' ',
+        width: 20,
+        total: totalBytes,
+      });
+    }
+    const delta = downloadedBytes - lastDownloadedBytes;
+    lastDownloadedBytes = downloadedBytes;
+    progressBar.tick(delta);
+  }
+
+  function toMegabytes(bytes) {
+    const mb = bytes / 1024 / 1024;
+    return `${Math.round(mb * 10) / 10} Mb`;
+  }
 }
 
 module.exports = installations;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "The Chromium Authors",
   "license": "Apache-2.0",
   "dependencies": {
+    "progress": "^2.0.1",
     "puppeteer-core": "^1.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Following values are supported:
- ['stable'] - use installed chrome (default option),
- ['*'] - use any installed chrome or download latest chromium,
- ['chromium'] - always download chromium,
- ['r599821'] - use specific chromium revision, revision should be available on all target platforms.

