### PR TITLE
package.json: add Windows lint command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "lint": "([ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .)",
+    "winlint": "( set CI=true  && eslint --quiet -f codeframe . || eslint .)",
     "test": "node rpc/test.js lib/test.js"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "lint": "([ \"$CI\" = true ] && eslint --quiet -f codeframe . || eslint .)",
-    "winlint": "( set CI=true  && eslint --quiet -f codeframe . || eslint .)",
+    "winlint": "(if defined CI (eslint --quiet -f codeframe .) else (eslint .))",
     "test": "node rpc/test.js lib/test.js"
   },
   "keywords": [],


### PR DESCRIPTION
We can't use `npm run lint`  to checks using Windows.