### PR TITLE
fix(xterm): bump xterm version to fix vulnerability

### DIFF
--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "carlo": "^0.9.0",
     "ndb-node-pty-prebuilt": "^0.8.0",
-    "xterm": "3.8.0"
+    "xterm": "~3.8.1"
   }
 }


### PR DESCRIPTION
xterm 3.8.0 has some remote code execution vulnerability. Was fixed in 3.8.1