### PR TITLE
Allow configuration of where the RPC content script is read from via rpcContentScriptDir

### DIFF
--- a/API.md
+++ b/API.md
@@ -72,6 +72,7 @@ Please refer to the Puppeteer [documentation](https://pptr.dev) for details on h
   - `icon` <[Buffer]|[string]> Application icon to be used in the system dock. Either buffer containing PNG or a path to the PNG file on the file system. This feature is only available in Chrome M72+. One can use `'canary'` channel to see it in action before M72 hits stable.
   - `paramsForReuse` <\*> Optional parameters to share between Carlo instances. See [Window.paramsForReuse](#windowparamsforreuse) for details.
   - `title` <[string]> Application title.
+  - `rpcContentScriptDir` <[string]> Override the path to Carlo's RPC content scripts (which must be accessible by fs.readFile).
   - `userDataDir` <[string]> Path to a [User Data Directory](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md). This folder is created upon the first app launch and contains user settings and Web storage data. Defaults to `'.profile'`.
   - `executablePath` <[string]> Path to a Chromium or Chrome executable to run instead of the automatically located Chrome. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). Carlo is only guaranteed to work with the latest Chrome stable version.
   - `args` <[Array]<[string]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](https://peter.sh/experiments/chromium-command-line-switches/).

--- a/lib/carlo.js
+++ b/lib/carlo.js
@@ -387,7 +387,7 @@ class Window extends EventEmitter {
   async configureRpcOnce_() {
     await this.page_.exposeFunction('receivedFromChild', data => this.receivedFromChild_(data));
 
-    const rpcFile = (await fsReadFile(__dirname + '/../rpc/rpc.js')).toString();
+    const rpcFile = (await fsReadFile(path.join(this.options_.rpcContentScriptDir, 'rpc.js'))).toString();
     const features = [ require('./features/shortcuts.js'),
                        require('./features/file_info.js') ];
 
@@ -590,6 +590,7 @@ async function launch(options = {}) {
   if (!options.bgcolor)
     options.bgcolor = '#ffffff';
   options.localDataDir = options.localDataDir || path.join(__dirname, '.local-data');
+  options.rpcContentScriptDir = options.rpcContentScriptDir || path.join(__dirname, '../rpc');
 
   const { executablePath, type } = await findChrome(options);
   if (!executablePath) {


### PR DESCRIPTION
This allows the RPC content script to be arbitrary read from any directory, rather than the default `__dirname + '../rpc/rpc.js`. This is important in situations where `node_modules` may be inaccessible in certain situations, such as in production builds.