### PR TITLE
fix(example): photobooth works on chrome stable

### DIFF
--- a/examples/photobooth/main.js
+++ b/examples/photobooth/main.js
@@ -30,7 +30,7 @@ const os = require('os');
         width: 800,
         height: 648 + 24,
         icon: path.join(__dirname, '/app_icon.png'),
-        channel: ['canary'],
+        channel: ['canary', 'stable'],
         localDataDir: path.join(os.homedir(), '.carlophotobooth'),
       });
   } catch(e) {
@@ -41,7 +41,6 @@ const os = require('os');
   app.on('exit', () => process.exit());
   // New windows are opened when this app is started again from command line.
   app.on('window', window => window.load('index.html'));
-  console.log('This example requires Chrome 72 (Chrome Canary) to function.');
   app.serveFolder(path.join(__dirname, '/www'));
   await app.exposeFunction('saveImage', saveImage);
   await app.load('index.html');


### PR DESCRIPTION
Chrome 72 is stable now, no reason to refuse launching on it.

Without this patch, the example failed with
```
Could not find Chrome installation, please make sure Chrome browser is installed from https://www.google.com/chrome/.
```

Btw, the now-removed warning was not working as it should have been, as it was not printed when carlo failed to find Chrome Canary, leaving the user with no idea why doesn't this example work when Chrome is installed.