### PR TITLE
fix(shortcuts): use event.key to get key

### DIFF
--- a/lib/features/shortcuts.js
+++ b/lib/features/shortcuts.js
@@ -59,7 +59,7 @@ module.exports = function install(hostWindow) {
 
   document.addEventListener('keydown', preventDefaultShortcuts, false);
   document.addEventListener('keydown', event => {
-    if (event.code === 'KeyQ' && (event.metaKey || event.ctrlKey)) {
+    if ((event.key === 'q' || event.key === 'Q') && (event.metaKey || event.ctrlKey)) {
       hostWindow.closeBrowser();
       event.preventDefault();
     }


### PR DESCRIPTION
As stated in [1] in French layout event.code returns `KeyQ` for letter `A`.
It forces `carlo` app to exit on `Ctrl` + `Shift` + `A` instead of `Q`.
Bug originally reported here: https://github.com/GoogleChromeLabs/ndb/issues/225

[1] https://hacks.mozilla.org/2017/03/internationalize-your-keyboard-controls/