### PR TITLE
fix(launcher): add unused CHROME_PATH to the array of installed executables

### DIFF
--- a/lib/find_chrome.js
+++ b/lib/find_chrome.js
@@ -53,6 +53,10 @@ function darwin(canary) {
 function linux(canary) {
   let installations = [];
 
+  // Look into CHROME_PATH env variable
+  if (process.env.CHROME_PATH && canAccess(process.env.CHROME_PATH))
+    installations.push(process.env.CHROME_PATH);
+
   // Look into the directories where .desktop are saved on gnome based distro's
   const desktopInstallationFolders = [
     path.join(require('os').homedir(), '.local/share/applications/'),


### PR DESCRIPTION
Although the error says
> The environment variable CHROME_PATH must be set to executable of a build of Chromium version 54.0 or later.

`CHROME_PATH` is never added to `installations`.